### PR TITLE
Fix transaction history retrieval

### DIFF
--- a/internal/transactions/handler.go
+++ b/internal/transactions/handler.go
@@ -47,7 +47,7 @@ func (h *TransactionHandler) Transfer(w http.ResponseWriter, r *http.Request) {
 func (h *TransactionHandler) GetHistory(w http.ResponseWriter, r *http.Request) {
 	userID := r.Context().Value(middleware.ContextUserIDKey).(string)
 
-	transactions, err := h.service.GetByAccount(r.Context(), userID)
+	transactions, err := h.service.GetByUser(r.Context(), userID)
 	if err != nil {
 		http.Error(w, "Error retrieving history", http.StatusInternalServerError)
 		return

--- a/internal/transactions/service.go
+++ b/internal/transactions/service.go
@@ -13,6 +13,8 @@ import (
 type TransactionService interface {
 	Transfer(ctx context.Context, fromID, toID string, amount float64, currency string) (*Transaction, error)
 	GetByAccount(ctx context.Context, accountID string) ([]Transaction, error)
+	// GetByUser retrieves transactions for the account associated with the given user.
+	GetByUser(ctx context.Context, userID string) ([]Transaction, error)
 	GenerateStatementCSV(transactions []Transaction, filePath string) error
 }
 
@@ -25,6 +27,16 @@ type transactionService struct {
 // GetByAccount implements TransactionService.
 func (s *transactionService) GetByAccount(ctx context.Context, accountID string) ([]Transaction, error) {
 	return s.repo.GetByAccount(ctx, accountID)
+
+}
+
+// GetByUser implements TransactionService.
+func (s *transactionService) GetByUser(ctx context.Context, userID string) ([]Transaction, error) {
+	acc, err := s.reader.GetAccountByUserID(ctx, userID)
+	if err != nil || acc == nil {
+		return nil, errors.New("account not found")
+	}
+	return s.repo.GetByAccount(ctx, acc.ID)
 
 }
 

--- a/internal/transactions/service_test.go
+++ b/internal/transactions/service_test.go
@@ -1,0 +1,55 @@
+package transactions
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+type mockRepo struct {
+	gotAccountID string
+	transactions []Transaction
+}
+
+func (m *mockRepo) Create(ctx context.Context, tx *Transaction) error { return nil }
+func (m *mockRepo) GetByAccount(ctx context.Context, accountID string) ([]Transaction, error) {
+	m.gotAccountID = accountID
+	return m.transactions, nil
+}
+
+type mockReader struct {
+	acc *AccountInfo
+	err error
+}
+
+func (m *mockReader) GetAccountByUserID(ctx context.Context, userID string) (*AccountInfo, error) {
+	return m.acc, m.err
+}
+
+func TestTransactionService_GetByUser(t *testing.T) {
+	repo := &mockRepo{transactions: []Transaction{{ID: "tx1"}}}
+	reader := &mockReader{acc: &AccountInfo{ID: "acc123"}}
+	svc := NewTransactionService(repo, nil, reader)
+
+	txs, err := svc.GetByUser(context.Background(), "user1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.gotAccountID != "acc123" {
+		t.Errorf("expected repo to be called with accountID acc123, got %s", repo.gotAccountID)
+	}
+	if !reflect.DeepEqual(txs, repo.transactions) {
+		t.Errorf("expected %v, got %v", repo.transactions, txs)
+	}
+}
+
+func TestTransactionService_GetByUser_NoAccount(t *testing.T) {
+	repo := &mockRepo{}
+	reader := &mockReader{acc: nil}
+	svc := NewTransactionService(repo, nil, reader)
+
+	_, err := svc.GetByUser(context.Background(), "user1")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- add GetByUser to `TransactionService` and use in handler
- add tests for GetByUser logic

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684e15fe14a883218f5d8c03d88df32d